### PR TITLE
class Alpr: Set self.loaded to False before exception

### DIFF
--- a/src/bindings/python/openalpr/openalpr.py
+++ b/src/bindings/python/openalpr/openalpr.py
@@ -42,6 +42,7 @@ class Alpr:
         :param runtime_dir: The path to the OpenALPR runtime data directory
         :return: An OpenALPR instance
         """
+        self.loaded = False
         country = _convert_to_charp(country)
         config_file = _convert_to_charp(config_file)
         runtime_dir = _convert_to_charp(runtime_dir)


### PR DESCRIPTION
If an exception is raised (like line 62, etc.) then self.loaded is never defined so subsequent code fails when trying to determine if Alpr has successfully loaded.